### PR TITLE
Update vars.yaml

### DIFF
--- a/vars.yaml
+++ b/vars.yaml
@@ -61,8 +61,8 @@ v_rhcos_initramfs: "https://mirror.openshift.com/pub/openshift-v4/dependencies/r
 v_rhcos_install_kernel: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/latest/rhcos-{{openshift_build}}.0-x86_64-installer-kernel"
 
 # OCP Installer
-v_ocp_client: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux-{{openshift_build}}.0.tar.gz"
-v_ocp_installer: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-install-linux-{{openshift_build}}.0.tar.gz"
+v_ocp_client: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux-{{openshift_build}}.1.tar.gz"
+v_ocp_installer: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-install-linux-{{openshift_build}}.1.tar.gz"
 
 
 


### PR DESCRIPTION
The v_ocp_client latest points to 4.3.1 and not 4.3.0.  The url=https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.3/openshift-client-linux-4.3.0.tar.gz is not found.
The latest v_ocp_installer also points to 4.3.1 and not 4.3.0